### PR TITLE
added missing where in options.packages.find

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,7 @@ install_requires =
     intervaltree
 
 [options.packages.find]
+where = src
 exclude =
     tests.*
     tests


### PR DESCRIPTION
After installing the package from pypi or this repository using pip, the import of bioc fails:
```
Python 3.10.4 (main, Mar 23 2022, 23:05:40) [GCC 11.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import bioc
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ModuleNotFoundError: No module named 'bioc'
```

This pull request adds the missing line `where = src` to the `[options.packages.find]` section of `setup.cfg` as described in https://setuptools.pypa.io/en/latest/userguide/declarative_config.html#using-a-src-layout
After this, the import of bioc is successful.
