### PR TITLE
Fix the URL in the setup file so Pypi has the right link

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,7 @@ description = bioc - Processing BioC, Brat, and PubTator with Python
 long_description = file: README.md
 long_description_content_type = text/markdown
 # The project's main homepage.
-url = https://github.com/bionlplab/bioc'
+url = https://github.com/bionlplab/bioc
 license = MIT License
 keywords = bioc, brat, pubtator
 # See https://pypi.org/classifiers/


### PR DESCRIPTION
A teeny tiny fix to remove an apostrophe in the package URL for pypi